### PR TITLE
Added support for POT header

### DIFF
--- a/src/extractAndWritePOTFromMessagesSync.js
+++ b/src/extractAndWritePOTFromMessagesSync.js
@@ -20,7 +20,7 @@ function extractAndWritePOTFromMessagesSync(srcPatterns, { messageKey, output, h
     potCreationDate: new Date(),
     charset: 'UTF-8',
     encoding: '8bit',
-    ...headerOptions
+    ...headerOptions,
   });
 
   result += flowRight(

--- a/src/extractAndWritePOTFromMessagesSync.js
+++ b/src/extractAndWritePOTFromMessagesSync.js
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import flowRight from 'lodash/flowRight';
 import readAllMessageAsObjectSync from './readAllMessageAsObjectSync';
 import potFormater from './potFormater';
+import potHeader from './potHeader';
 
 const customKeyMapper = (message, messageKey, filename) => ({
   [message[messageKey]]: [{ ...message, filename }],
@@ -12,10 +13,17 @@ const customKeyMapper = (message, messageKey, filename) => ({
 const customKeyMapperFactory = (messageKey = 'defaultMessage') =>
   (message, filename) => customKeyMapper(message, messageKey, filename);
 
-function extractAndWritePOTFromMessagesSync(srcPatterns, { messageKey, output }) {
+function extractAndWritePOTFromMessagesSync(srcPatterns, { messageKey, output, headerOptions }) {
   const mapper = messageKey ? customKeyMapperFactory(messageKey) : undefined;
 
-  const result = flowRight(
+  let result = potHeader({
+    potCreationDate: new Date(),
+    charset: 'UTF-8',
+    encoding: '8bit',
+    ...headerOptions
+  });
+
+  result += flowRight(
     potFormater,                // 2. return formated string
     readAllMessageAsObjectSync, // 1. return messages object
   )(srcPatterns, mapper);

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import extractAndWritePOTFromMessagesSync from './extractAndWritePOTFromMessagesSync';
 import filterPOAndWriteTranslateSync from './filterPOAndWriteTranslateSync';
 import potFormater from './potFormater';
+import potHeader from './potHeader';
 import readAllMessageAsObjectSync from './readAllMessageAsObjectSync';
 import readAllPOAsObjectSync from './readAllPOAsObjectSync';
 
@@ -8,6 +9,7 @@ export default {
   extractAndWritePOTFromMessagesSync,
   filterPOAndWriteTranslateSync,
   potFormater,
+  potHeader,
   readAllMessageAsObjectSync,
   readAllPOAsObjectSync,
 };

--- a/src/potHeader.js
+++ b/src/potHeader.js
@@ -14,15 +14,16 @@
  * @author Guillaume Boddaert
  */
 
-export const potHeader = (options = {}) => {
+const potHeader = (options = {}) => {
   let header = '';
 
   if (options.comments) {
+    let comments = options.comments;
     if (!Array.isArray(options.comments)) {
-      options.comments = [options.comments];
+      comments = [options.comments];
     }
-    const comments = options.comments.reduce((o, n) => o.concat(n.split('\n')), []);
-    header += comments.map(comment => `# ${comment}`).join('\n') + '\n';
+    comments = comments.reduce((o, n) => o.concat(n.split('\n')), []);
+    header += `${comments.map(comment => `# ${comment}`).join('\n')}\n`;
   }
   header += 'msgid ""\nmsgstr ""\n';
 
@@ -38,10 +39,10 @@ export const potHeader = (options = {}) => {
   if (options.encoding) {
     header += `"Content-Transfer-Encoding: ${options.encoding}\\n"\n`;
   }
-  header += `"MIME-Version: 1.0\\n"\n`;
-  header += `"X-Generator: react-intl-po\\n"\n`;
+  header += '"MIME-Version: 1.0\\n"\n';
+  header += '"X-Generator: react-intl-po\\n"\n';
   header += '\n\n';
   return header;
 };
 
-export default potHeader
+export default potHeader;

--- a/src/potHeader.js
+++ b/src/potHeader.js
@@ -1,0 +1,47 @@
+/**
+ * Create a POT header string
+ * @param {Object} options
+ * @param {String|String[]} [options.comments]
+ * @param {Date} [options.potCreationDate] used for POT-Creation-Date
+ * @param {String} [options.projectIdVersion] Project-Id-Version
+ * @param {String} [options.charset]
+ * @param {String} [options.encoding]
+ * @return {String} potSource
+ *
+ * example: see tests
+ *
+ * @see https://www.gnu.org/software/trans-coord/manual/gnun/html_node/PO-Header.html
+ * @author Guillaume Boddaert
+ */
+
+export const potHeader = (options = {}) => {
+  let header = '';
+
+  if (options.comments) {
+    if (!Array.isArray(options.comments)) {
+      options.comments = [options.comments];
+    }
+    const comments = options.comments.reduce((o, n) => o.concat(n.split('\n')), []);
+    header += comments.map(comment => `# ${comment}`).join('\n') + '\n';
+  }
+  header += 'msgid ""\nmsgstr ""\n';
+
+  if (options.projectIdVersion) {
+    header += `"Project-Id-Version: ${options.projectIdVersion}\\n"\n`;
+  }
+  if (options.potCreationDate) {
+    header += `"POT-Creation-Date: ${options.potCreationDate.toISOString()}\\n"\n`;
+  }
+  if (options.charset) {
+    header += `"Content-Type: text/plain; charset=${options.charset}\\n"\n`;
+  }
+  if (options.encoding) {
+    header += `"Content-Transfer-Encoding: ${options.encoding}\\n"\n`;
+  }
+  header += `"MIME-Version: 1.0\\n"\n`;
+  header += `"X-Generator: react-intl-po\\n"\n`;
+  header += '\n\n';
+  return header;
+};
+
+export default potHeader

--- a/test/extractAndWritePOTFromMessagesSync.test.js
+++ b/test/extractAndWritePOTFromMessagesSync.test.js
@@ -9,7 +9,7 @@ test('should return a function', (t) => {
 
 test('should return messages object with default mapper', (t) => {
   const output = './temp/extract.pot';
-  const headerOptions = { potCreationDate: new Date(2017, 1, 1, 11, 23, 12) };
+  const headerOptions = { potCreationDate: new Date(Date.UTC(2017, 1, 1, 11, 23, 12)) };
 
   extractAndWritePOTFromMessagesSync('./messages/**/*.json', { output, headerOptions });
 
@@ -17,7 +17,7 @@ test('should return messages object with default mapper', (t) => {
     fs.readFileSync(output, 'utf8'),
     'msgid ""\n' +
     'msgstr ""\n' +
-    '"POT-Creation-Date: 2017-02-01T10:23:12.000Z\\n"\n' +
+    '"POT-Creation-Date: 2017-02-01T11:23:12.000Z\\n"\n' +
     '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
     '"Content-Transfer-Encoding: 8bit\\n"\n' +
     '"MIME-Version: 1.0\\n"\n' +
@@ -45,14 +45,14 @@ test('should return messages object with default mapper', (t) => {
 
 test('should return messages object with custom message key mapper', (t) => {
   const output = './temp/extract2.pot';
-  const headerOptions = { potCreationDate: new Date(2017, 1, 1, 11, 23, 12) };
+  const headerOptions = { potCreationDate: new Date(Date.UTC(2017, 1, 1, 11, 23, 12)) };
 
   extractAndWritePOTFromMessagesSync('./messages/**/*.json', { messageKey: 'id', output, headerOptions });
   t.is(
     fs.readFileSync(output, 'utf8'),
     'msgid ""\n' +
     'msgstr ""\n' +
-    '"POT-Creation-Date: 2017-02-01T10:23:12.000Z\\n"\n' +
+    '"POT-Creation-Date: 2017-02-01T11:23:12.000Z\\n"\n' +
     '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
     '"Content-Transfer-Encoding: 8bit\\n"\n' +
     '"MIME-Version: 1.0\\n"\n' +

--- a/test/extractAndWritePOTFromMessagesSync.test.js
+++ b/test/extractAndWritePOTFromMessagesSync.test.js
@@ -9,7 +9,7 @@ test('should return a function', (t) => {
 
 test('should return messages object with default mapper', (t) => {
   const output = './temp/extract.pot';
-  const headerOptions = { potCreationDate: new Date(2017, 1, 1, 11, 23, 12)};
+  const headerOptions = { potCreationDate: new Date(2017, 1, 1, 11, 23, 12) };
 
   extractAndWritePOTFromMessagesSync('./messages/**/*.json', { output, headerOptions });
 
@@ -45,7 +45,7 @@ test('should return messages object with default mapper', (t) => {
 
 test('should return messages object with custom message key mapper', (t) => {
   const output = './temp/extract2.pot';
-  const headerOptions = { potCreationDate: new Date(2017, 1, 1, 11, 23, 12)};
+  const headerOptions = { potCreationDate: new Date(2017, 1, 1, 11, 23, 12) };
 
   extractAndWritePOTFromMessagesSync('./messages/**/*.json', { messageKey: 'id', output, headerOptions });
   t.is(

--- a/test/extractAndWritePOTFromMessagesSync.test.js
+++ b/test/extractAndWritePOTFromMessagesSync.test.js
@@ -9,10 +9,21 @@ test('should return a function', (t) => {
 
 test('should return messages object with default mapper', (t) => {
   const output = './temp/extract.pot';
+  const headerOptions = { potCreationDate: new Date(2017, 1, 1, 11, 23, 12)};
 
-  extractAndWritePOTFromMessagesSync('./messages/**/*.json', { output });
+  extractAndWritePOTFromMessagesSync('./messages/**/*.json', { output, headerOptions });
+
   t.is(
     fs.readFileSync(output, 'utf8'),
+    'msgid ""\n' +
+    'msgstr ""\n' +
+    '"POT-Creation-Date: 2017-02-01T10:23:12.000Z\\n"\n' +
+    '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
+    '"Content-Transfer-Encoding: 8bit\\n"\n' +
+    '"MIME-Version: 1.0\\n"\n' +
+    '"X-Generator: react-intl-po\\n"\n' +
+    '\n' +
+    '\n' +
     '#: ./messages/src/containers/App/App.json\n' +
     '#. [App.Creator] - Creator\n' +
     '#: ./messages/src/containers/NotFound/messages.json\n' +
@@ -33,11 +44,21 @@ test('should return messages object with default mapper', (t) => {
 });
 
 test('should return messages object with custom message key mapper', (t) => {
-  const output = './temp/extract.pot';
+  const output = './temp/extract2.pot';
+  const headerOptions = { potCreationDate: new Date(2017, 1, 1, 11, 23, 12)};
 
-  extractAndWritePOTFromMessagesSync('./messages/**/*.json', { messageKey: 'id', output });
+  extractAndWritePOTFromMessagesSync('./messages/**/*.json', { messageKey: 'id', output, headerOptions });
   t.is(
     fs.readFileSync(output, 'utf8'),
+    'msgid ""\n' +
+    'msgstr ""\n' +
+    '"POT-Creation-Date: 2017-02-01T10:23:12.000Z\\n"\n' +
+    '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
+    '"Content-Transfer-Encoding: 8bit\\n"\n' +
+    '"MIME-Version: 1.0\\n"\n' +
+    '"X-Generator: react-intl-po\\n"\n' +
+    '\n' +
+    '\n' +
     '#: ./messages/src/containers/App/App.json\n' +
     '#. [App.Creator] - Creator\n' +
     'msgid "App.Creator"\n' +

--- a/test/potHeader.test.js
+++ b/test/potHeader.test.js
@@ -1,0 +1,97 @@
+import test from 'ava';
+import potHeader from '../src/potHeader';
+
+test('should return a function', (t) => {
+  t.is(typeof potHeader, 'function');
+});
+
+test('should return pot header, without any parameter', (t) => {
+  t.is(
+    potHeader(),
+    'msgid ""\n' +
+    'msgstr ""\n' +
+    '"MIME-Version: 1.0\\n"\n' +
+    '"X-Generator: react-intl-po\\n"\n' +
+    '\n\n',
+  );
+});
+
+test('should return pot header, without empty options', (t) => {
+  t.is(
+    potHeader({}),
+    'msgid ""\n' +
+    'msgstr ""\n' +
+    '"MIME-Version: 1.0\\n"\n' +
+    '"X-Generator: react-intl-po\\n"\n' +
+    '\n\n',
+  );
+});
+
+test('should return pot header, with a single comment', (t) => {
+  t.is(
+    potHeader({
+      comments: 'This is a single line comment'
+    }),
+    '# This is a single line comment\n' +
+    'msgid ""\n' +
+    'msgstr ""\n' +
+    '"MIME-Version: 1.0\\n"\n' +
+    '"X-Generator: react-intl-po\\n"\n' +
+    '\n\n',
+  );
+});
+
+test('should return pot header, with a single comment, with CR in it', (t) => {
+  t.is(
+    potHeader({
+      comments: 'This is a multi-line\ncomment\n'
+    }),
+    '# This is a multi-line\n' +
+    '# comment\n' +
+    '# \n' +
+    'msgid ""\n' +
+    'msgstr ""\n' +
+    '"MIME-Version: 1.0\\n"\n' +
+    '"X-Generator: react-intl-po\\n"\n' +
+    '\n\n',
+  );
+});
+
+test('should return pot header, with a list of comments', (t) => {
+  t.is(
+    potHeader({
+      comments: ['A', 'B', 'C']
+    }),
+    '# A\n' +
+    '# B\n' +
+    '# C\n' +
+    'msgid ""\n' +
+    'msgstr ""\n' +
+    '"MIME-Version: 1.0\\n"\n' +
+    '"X-Generator: react-intl-po\\n"\n' +
+    '\n\n',
+  );
+});
+
+
+test('should return pot header, with all options', (t) => {
+  t.is(
+    potHeader({
+      comments: 'This is a single line comment',
+      projectIdVersion: 'FUBAR',
+      potCreationDate: new Date(1995,11,17,3,24,0),
+      charset: 'UTF-8',
+      encoding: '8bit'
+    }),
+    '# This is a single line comment\n' +
+    'msgid ""\n' +
+    'msgstr ""\n' +
+    '"Project-Id-Version: FUBAR\\n"\n' +
+    '"POT-Creation-Date: 1995-12-17T02:24:00.000Z\\n"\n' +
+    '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
+    '"Content-Transfer-Encoding: 8bit\\n"\n' +
+    '"MIME-Version: 1.0\\n"\n' +
+    '"X-Generator: react-intl-po\\n"\n' +
+    '\n\n',
+  );
+});

--- a/test/potHeader.test.js
+++ b/test/potHeader.test.js
@@ -30,7 +30,7 @@ test('should return pot header, without empty options', (t) => {
 test('should return pot header, with a single comment', (t) => {
   t.is(
     potHeader({
-      comments: 'This is a single line comment'
+      comments: 'This is a single line comment',
     }),
     '# This is a single line comment\n' +
     'msgid ""\n' +
@@ -44,7 +44,7 @@ test('should return pot header, with a single comment', (t) => {
 test('should return pot header, with a single comment, with CR in it', (t) => {
   t.is(
     potHeader({
-      comments: 'This is a multi-line\ncomment\n'
+      comments: 'This is a multi-line\ncomment\n',
     }),
     '# This is a multi-line\n' +
     '# comment\n' +
@@ -60,7 +60,7 @@ test('should return pot header, with a single comment, with CR in it', (t) => {
 test('should return pot header, with a list of comments', (t) => {
   t.is(
     potHeader({
-      comments: ['A', 'B', 'C']
+      comments: ['A', 'B', 'C'],
     }),
     '# A\n' +
     '# B\n' +
@@ -79,9 +79,9 @@ test('should return pot header, with all options', (t) => {
     potHeader({
       comments: 'This is a single line comment',
       projectIdVersion: 'FUBAR',
-      potCreationDate: new Date(1995,11,17,3,24,0),
+      potCreationDate: new Date(1995, 11, 17, 3, 24, 0),
       charset: 'UTF-8',
-      encoding: '8bit'
+      encoding: '8bit',
     }),
     '# This is a single line comment\n' +
     'msgid ""\n' +

--- a/test/potHeader.test.js
+++ b/test/potHeader.test.js
@@ -79,7 +79,7 @@ test('should return pot header, with all options', (t) => {
     potHeader({
       comments: 'This is a single line comment',
       projectIdVersion: 'FUBAR',
-      potCreationDate: new Date(1995, 11, 17, 3, 24, 0),
+      potCreationDate: new Date(Date.UTC(1995, 11, 17, 3, 24, 0)),
       charset: 'UTF-8',
       encoding: '8bit',
     }),
@@ -87,7 +87,7 @@ test('should return pot header, with all options', (t) => {
     'msgid ""\n' +
     'msgstr ""\n' +
     '"Project-Id-Version: FUBAR\\n"\n' +
-    '"POT-Creation-Date: 1995-12-17T02:24:00.000Z\\n"\n' +
+    '"POT-Creation-Date: 1995-12-17T03:24:00.000Z\\n"\n' +
     '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
     '"Content-Transfer-Encoding: 8bit\\n"\n' +
     '"MIME-Version: 1.0\\n"\n' +


### PR DESCRIPTION
As seen in #54, this feature is required for multiple reason. I've setup a minimal support for this feature forcing:

* empty msgid and msgstr
* `POT-Creation-Date` header
* `Content-Type` / `Content-Transfer-Encoding` (forced to UTF-8 / 8bit)
* `MIME-Version`
* `X-Generator` for the pride :)

Yet the `potHeader` function allow you to add comments and projectid, but I achieved what I needed.

There are also unit tests.