### PR TITLE
defaultMessage information added to message metadata if mapping is not using defaultMessage as key

### DIFF
--- a/src/extractAndWritePOTFromMessagesSync.js
+++ b/src/extractAndWritePOTFromMessagesSync.js
@@ -20,7 +20,7 @@ function extractAndWritePOTFromMessagesSync(srcPatterns, { messageKey, output, h
     potCreationDate: new Date(),
     charset: 'UTF-8',
     encoding: '8bit',
-    ...headerOptions
+    ...headerOptions,
   });
 
   result += flowRight(

--- a/src/extractAndWritePOTFromMessagesSync.js
+++ b/src/extractAndWritePOTFromMessagesSync.js
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import flowRight from 'lodash/flowRight';
 import readAllMessageAsObjectSync from './readAllMessageAsObjectSync';
 import potFormater from './potFormater';
+import potHeader from './potHeader';
 
 const customKeyMapper = (message, messageKey, filename) => ({
   [message[messageKey]]: [{ ...message, filename }],
@@ -12,10 +13,17 @@ const customKeyMapper = (message, messageKey, filename) => ({
 const customKeyMapperFactory = (messageKey = 'defaultMessage') =>
   (message, filename) => customKeyMapper(message, messageKey, filename);
 
-function extractAndWritePOTFromMessagesSync(srcPatterns, { messageKey, output }) {
+function extractAndWritePOTFromMessagesSync(srcPatterns, { messageKey, output, headerOptions }) {
   const mapper = messageKey ? customKeyMapperFactory(messageKey) : undefined;
 
-  const result = flowRight(
+  let result = potHeader({
+    potCreationDate: new Date(),
+    charset: 'UTF-8',
+    encoding: '8bit',
+    ...headerOptions
+  });
+
+  result += flowRight(
     potFormater,                // 2. return formated string
     readAllMessageAsObjectSync, // 1. return messages object
   )(srcPatterns, mapper);

--- a/src/extractAndWritePOTFromMessagesSync.js
+++ b/src/extractAndWritePOTFromMessagesSync.js
@@ -7,7 +7,7 @@ import potFormater from './potFormater';
 import potHeader from './potHeader';
 
 const customKeyMapper = (message, messageKey, filename) => ({
-  [message[messageKey]]: [{ ...message, filename }],
+  [message[messageKey]]: [{ ...message, filename, mappedBy: messageKey }],
 });
 
 const customKeyMapperFactory = (messageKey = 'defaultMessage') =>

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import extractAndWritePOTFromMessagesSync from './extractAndWritePOTFromMessagesSync';
 import filterPOAndWriteTranslateSync from './filterPOAndWriteTranslateSync';
 import potFormater from './potFormater';
+import potHeader from './potHeader';
 import readAllMessageAsObjectSync from './readAllMessageAsObjectSync';
 import readAllPOAsObjectSync from './readAllPOAsObjectSync';
 
@@ -8,6 +9,7 @@ export default {
   extractAndWritePOTFromMessagesSync,
   filterPOAndWriteTranslateSync,
   potFormater,
+  potHeader,
   readAllMessageAsObjectSync,
   readAllPOAsObjectSync,
 };

--- a/src/potFormater.js
+++ b/src/potFormater.js
@@ -1,20 +1,55 @@
 /**
+ * Ensure that multi-line strings are properly commented out
+ *
+ * For instance:
+ * This is\nmy multi-line\ncomment
+ *
+ * should be escaped as :
+ * #. This is
+ * #. my multi-line
+ * #. comment
+ *
+ * @param {String} commentPrefix
+ * @param {String} rawComment
+ * @returns {String}
+ *
+ * @author Guillaume Boddaert
+ */
+const potCommentMultiLineWrapper = (commentPrefix, rawComment) => {
+  const comments = rawComment.split('\n');
+  return comments.reduce((a, b) => `${a}${commentPrefix} ${b}\n`, '');
+};
+
+
+/**
  * Formatting POT comments
- * @param {Object[]}
+ * @param {Object[]} messageList
  * @return {String}
  *
  * example: see tests
  *
  * @author Michael Hsu
+ * @author Guillaume Boddaert
  */
 const potCommentsFormater = messageList =>
-  messageList.reduce((acc, { filename, id, description }) =>
-    `${acc}#: ${filename}\n#. [${id}] - ${description}\n`
-  , '');
+  messageList.reduce((acc, { filename, id, description, defaultMessage, mappedBy }) => {
+    let out = acc;
+    out += potCommentMultiLineWrapper('#:', filename);
+    if (description) {
+      out += potCommentMultiLineWrapper('#.', `[${id}] - ${description}`);
+    } else {
+      out += potCommentMultiLineWrapper('#.', `[${id}]`);
+    }
+    if (mappedBy && mappedBy !== 'defaultMessage') {
+      out += potCommentMultiLineWrapper('#.', `defaultMessage is:\n${defaultMessage}`);
+    }
+
+    return out;
+  }, '');
 
 /**
  * Formatting POT comments
- * @param {Object}
+ * @param {Object} messageObject
  * @return {String}
  *
  * example: see tests

--- a/src/potHeader.js
+++ b/src/potHeader.js
@@ -14,15 +14,16 @@
  * @author Guillaume Boddaert
  */
 
-export const potHeader = (options = {}) => {
+const potHeader = (options = {}) => {
   let header = '';
 
   if (options.comments) {
+    let comments = options.comments;
     if (!Array.isArray(options.comments)) {
-      options.comments = [options.comments];
+      comments = [options.comments];
     }
-    const comments = options.comments.reduce((o, n) => o.concat(n.split('\n')), []);
-    header += comments.map(comment => `# ${comment}`).join('\n') + '\n';
+    comments = comments.reduce((o, n) => o.concat(n.split('\n')), []);
+    header += `${comments.map(comment => `# ${comment}`).join('\n')}\n`;
   }
   header += 'msgid ""\nmsgstr ""\n';
 
@@ -38,10 +39,10 @@ export const potHeader = (options = {}) => {
   if (options.encoding) {
     header += `"Content-Transfer-Encoding: ${options.encoding}\\n"\n`;
   }
-  header += `"MIME-Version: 1.0\\n"\n`;
-  header += `"X-Generator: react-intl-po\\n"\n`;
+  header += '"MIME-Version: 1.0\\n"\n';
+  header += '"X-Generator: react-intl-po\\n"\n';
   header += '\n\n';
   return header;
 };
 
-export default potHeader
+export default potHeader;

--- a/src/potHeader.js
+++ b/src/potHeader.js
@@ -1,0 +1,47 @@
+/**
+ * Create a POT header string
+ * @param {Object} options
+ * @param {String|String[]} [options.comments]
+ * @param {Date} [options.potCreationDate] used for POT-Creation-Date
+ * @param {String} [options.projectIdVersion] Project-Id-Version
+ * @param {String} [options.charset]
+ * @param {String} [options.encoding]
+ * @return {String} potSource
+ *
+ * example: see tests
+ *
+ * @see https://www.gnu.org/software/trans-coord/manual/gnun/html_node/PO-Header.html
+ * @author Guillaume Boddaert
+ */
+
+export const potHeader = (options = {}) => {
+  let header = '';
+
+  if (options.comments) {
+    if (!Array.isArray(options.comments)) {
+      options.comments = [options.comments];
+    }
+    const comments = options.comments.reduce((o, n) => o.concat(n.split('\n')), []);
+    header += comments.map(comment => `# ${comment}`).join('\n') + '\n';
+  }
+  header += 'msgid ""\nmsgstr ""\n';
+
+  if (options.projectIdVersion) {
+    header += `"Project-Id-Version: ${options.projectIdVersion}\\n"\n`;
+  }
+  if (options.potCreationDate) {
+    header += `"POT-Creation-Date: ${options.potCreationDate.toISOString()}\\n"\n`;
+  }
+  if (options.charset) {
+    header += `"Content-Type: text/plain; charset=${options.charset}\\n"\n`;
+  }
+  if (options.encoding) {
+    header += `"Content-Transfer-Encoding: ${options.encoding}\\n"\n`;
+  }
+  header += `"MIME-Version: 1.0\\n"\n`;
+  header += `"X-Generator: react-intl-po\\n"\n`;
+  header += '\n\n';
+  return header;
+};
+
+export default potHeader

--- a/src/readAllMessageAsObjectSync.js
+++ b/src/readAllMessageAsObjectSync.js
@@ -6,7 +6,7 @@ import toObjectBy from 'to-object-by';
 
 // hint: Use defaultMessage as key by default
 const DEFAULT_MAPPER = (message, filename) => ({
-  [message.defaultMessage]: [{ ...message, filename }],
+  [message.defaultMessage]: [{ ...message, filename, mappedBy: 'defaultMessage' }],
 });
 
 /**

--- a/test/extractAndWritePOTFromMessagesSync.test.js
+++ b/test/extractAndWritePOTFromMessagesSync.test.js
@@ -9,7 +9,7 @@ test('should return a function', (t) => {
 
 test('should return messages object with default mapper', (t) => {
   const output = './temp/extract.pot';
-  const headerOptions = { potCreationDate: new Date(2017, 1, 1, 11, 23, 12) };
+  const headerOptions = { potCreationDate: new Date(Date.UTC(2017, 1, 1, 11, 23, 12)) };
 
   extractAndWritePOTFromMessagesSync('./messages/**/*.json', { output, headerOptions });
 
@@ -17,7 +17,7 @@ test('should return messages object with default mapper', (t) => {
     fs.readFileSync(output, 'utf8'),
     'msgid ""\n' +
     'msgstr ""\n' +
-    '"POT-Creation-Date: 2017-02-01T10:23:12.000Z\\n"\n' +
+    '"POT-Creation-Date: 2017-02-01T11:23:12.000Z\\n"\n' +
     '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
     '"Content-Transfer-Encoding: 8bit\\n"\n' +
     '"MIME-Version: 1.0\\n"\n' +
@@ -45,14 +45,14 @@ test('should return messages object with default mapper', (t) => {
 
 test('should return messages object with custom message key mapper', (t) => {
   const output = './temp/extract2.pot';
-  const headerOptions = { potCreationDate: new Date(2017, 1, 1, 11, 23, 12) };
+  const headerOptions = { potCreationDate: new Date(Date.UTC(2017, 1, 1, 11, 23, 12)) };
 
   extractAndWritePOTFromMessagesSync('./messages/**/*.json', { messageKey: 'id', output, headerOptions });
   t.is(
     fs.readFileSync(output, 'utf8'),
     'msgid ""\n' +
     'msgstr ""\n' +
-    '"POT-Creation-Date: 2017-02-01T10:23:12.000Z\\n"\n' +
+    '"POT-Creation-Date: 2017-02-01T11:23:12.000Z\\n"\n' +
     '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
     '"Content-Transfer-Encoding: 8bit\\n"\n' +
     '"MIME-Version: 1.0\\n"\n' +

--- a/test/extractAndWritePOTFromMessagesSync.test.js
+++ b/test/extractAndWritePOTFromMessagesSync.test.js
@@ -61,22 +61,32 @@ test('should return messages object with custom message key mapper', (t) => {
     '\n' +
     '#: ./messages/src/containers/App/App.json\n' +
     '#. [App.Creator] - Creator\n' +
+    '#. defaultMessage is:\n' +
+    '#. Creator\n' +
     'msgid "App.Creator"\n' +
     'msgstr ""\n\n' +
     '#: ./messages/src/containers/App/App.json\n' +
     '#. [App.errorButton] - Click error Button\n' +
+    '#. defaultMessage is:\n' +
+    '#. Go to MCS website\n' +
     'msgid "App.errorButton"\n' +
     'msgstr ""\n\n' +
     '#: ./messages/src/containers/App/App.json\n' +
     '#. [App.errorMessage] - The error message when api response as 404 not found\n' +
+    '#. defaultMessage is:\n' +
+    '#. The device is now private or deleted.\n' +
     'msgid "App.errorMessage"\n' +
     'msgstr ""\n\n' +
     '#: ./messages/src/containers/NotFound/messages.json\n' +
     '#. [NotFound.Creator] - Creator\n' +
+    '#. defaultMessage is:\n' +
+    '#. Creator\n' +
     'msgid "NotFound.Creator"\n' +
     'msgstr ""\n\n' +
     '#: ./messages/src/containers/NotFound/messages.json\n' +
     '#. [NotFound.errorButton] - Click error Button\n' +
+    '#. defaultMessage is:\n' +
+    '#. Go to MCS website\n' +
     'msgid "NotFound.errorButton"\n' +
     'msgstr ""\n',
   );

--- a/test/extractAndWritePOTFromMessagesSync.test.js
+++ b/test/extractAndWritePOTFromMessagesSync.test.js
@@ -9,7 +9,7 @@ test('should return a function', (t) => {
 
 test('should return messages object with default mapper', (t) => {
   const output = './temp/extract.pot';
-  const headerOptions = { potCreationDate: new Date(2017, 1, 1, 11, 23, 12)};
+  const headerOptions = { potCreationDate: new Date(2017, 1, 1, 11, 23, 12) };
 
   extractAndWritePOTFromMessagesSync('./messages/**/*.json', { output, headerOptions });
 
@@ -45,7 +45,7 @@ test('should return messages object with default mapper', (t) => {
 
 test('should return messages object with custom message key mapper', (t) => {
   const output = './temp/extract2.pot';
-  const headerOptions = { potCreationDate: new Date(2017, 1, 1, 11, 23, 12)};
+  const headerOptions = { potCreationDate: new Date(2017, 1, 1, 11, 23, 12) };
 
   extractAndWritePOTFromMessagesSync('./messages/**/*.json', { messageKey: 'id', output, headerOptions });
   t.is(

--- a/test/extractAndWritePOTFromMessagesSync.test.js
+++ b/test/extractAndWritePOTFromMessagesSync.test.js
@@ -9,10 +9,21 @@ test('should return a function', (t) => {
 
 test('should return messages object with default mapper', (t) => {
   const output = './temp/extract.pot';
+  const headerOptions = { potCreationDate: new Date(2017, 1, 1, 11, 23, 12)};
 
-  extractAndWritePOTFromMessagesSync('./messages/**/*.json', { output });
+  extractAndWritePOTFromMessagesSync('./messages/**/*.json', { output, headerOptions });
+
   t.is(
     fs.readFileSync(output, 'utf8'),
+    'msgid ""\n' +
+    'msgstr ""\n' +
+    '"POT-Creation-Date: 2017-02-01T10:23:12.000Z\\n"\n' +
+    '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
+    '"Content-Transfer-Encoding: 8bit\\n"\n' +
+    '"MIME-Version: 1.0\\n"\n' +
+    '"X-Generator: react-intl-po\\n"\n' +
+    '\n' +
+    '\n' +
     '#: ./messages/src/containers/App/App.json\n' +
     '#. [App.Creator] - Creator\n' +
     '#: ./messages/src/containers/NotFound/messages.json\n' +
@@ -33,11 +44,21 @@ test('should return messages object with default mapper', (t) => {
 });
 
 test('should return messages object with custom message key mapper', (t) => {
-  const output = './temp/extract.pot';
+  const output = './temp/extract2.pot';
+  const headerOptions = { potCreationDate: new Date(2017, 1, 1, 11, 23, 12)};
 
-  extractAndWritePOTFromMessagesSync('./messages/**/*.json', { messageKey: 'id', output });
+  extractAndWritePOTFromMessagesSync('./messages/**/*.json', { messageKey: 'id', output, headerOptions });
   t.is(
     fs.readFileSync(output, 'utf8'),
+    'msgid ""\n' +
+    'msgstr ""\n' +
+    '"POT-Creation-Date: 2017-02-01T10:23:12.000Z\\n"\n' +
+    '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
+    '"Content-Transfer-Encoding: 8bit\\n"\n' +
+    '"MIME-Version: 1.0\\n"\n' +
+    '"X-Generator: react-intl-po\\n"\n' +
+    '\n' +
+    '\n' +
     '#: ./messages/src/containers/App/App.json\n' +
     '#. [App.Creator] - Creator\n' +
     'msgid "App.Creator"\n' +

--- a/test/potFormater.test.js
+++ b/test/potFormater.test.js
@@ -31,3 +31,71 @@ test('should return pot formatted string', (t) => {
     'msgstr ""\n',
   );
 });
+
+test('should return pot formatted string, with explicit mapping specified and not defaultMessage', (t) => {
+  t.is(
+    potFormater({
+      'NotFound.errorButton': [
+        {
+          id: 'NotFound.errorButton',
+          description: 'Click error Button',
+          defaultMessage: 'Go to MCS website',
+          filename: './messages/src/containers/NotFound/messages.json',
+          mappedBy: 'id',
+        },
+      ],
+    }),
+    '#: ./messages/src/containers/NotFound/messages.json\n' +
+    '#. [NotFound.errorButton] - Click error Button\n' +
+    '#. defaultMessage is:\n' +
+    '#. Go to MCS website\n' +
+    'msgid "NotFound.errorButton"\n' +
+    'msgstr ""\n',
+  );
+});
+
+test('should return pot formatted string, with null or undefined description', (t) => {
+  t.is(
+    potFormater({
+      'Go to MCS website': [
+        {
+          id: 'NotFound.errorButton',
+          defaultMessage: 'Go to MCS website',
+          filename: './messages/src/containers/NotFound/messages.json',
+          mappedBy: 'defaultMessage',
+        },
+      ],
+    }),
+    '#: ./messages/src/containers/NotFound/messages.json\n' +
+    '#. [NotFound.errorButton]\n' +
+    'msgid "Go to MCS website"\n' +
+    'msgstr ""\n',
+  );
+});
+
+
+test('should return pot formatted string, with multi line values', (t) => {
+  t.is(
+    potFormater({
+      'NotFound.errorButton': [
+        {
+          id: 'NotFound.errorButton',
+          description: 'My description\nis\nquite\nlong.',
+          defaultMessage: 'This is\nmultiline',
+          filename: './messages/src/containers/NotFound/messages.json',
+          mappedBy: 'id',
+        },
+      ],
+    }),
+    '#: ./messages/src/containers/NotFound/messages.json\n' +
+    '#. [NotFound.errorButton] - My description\n' +
+    '#. is\n' +
+    '#. quite\n' +
+    '#. long.\n' +
+    '#. defaultMessage is:\n' +
+    '#. This is\n' +
+    '#. multiline\n' +
+    'msgid "NotFound.errorButton"\n' +
+    'msgstr ""\n',
+  );
+});

--- a/test/potHeader.test.js
+++ b/test/potHeader.test.js
@@ -1,0 +1,97 @@
+import test from 'ava';
+import potHeader from '../src/potHeader';
+
+test('should return a function', (t) => {
+  t.is(typeof potHeader, 'function');
+});
+
+test('should return pot header, without any parameter', (t) => {
+  t.is(
+    potHeader(),
+    'msgid ""\n' +
+    'msgstr ""\n' +
+    '"MIME-Version: 1.0\\n"\n' +
+    '"X-Generator: react-intl-po\\n"\n' +
+    '\n\n',
+  );
+});
+
+test('should return pot header, without empty options', (t) => {
+  t.is(
+    potHeader({}),
+    'msgid ""\n' +
+    'msgstr ""\n' +
+    '"MIME-Version: 1.0\\n"\n' +
+    '"X-Generator: react-intl-po\\n"\n' +
+    '\n\n',
+  );
+});
+
+test('should return pot header, with a single comment', (t) => {
+  t.is(
+    potHeader({
+      comments: 'This is a single line comment'
+    }),
+    '# This is a single line comment\n' +
+    'msgid ""\n' +
+    'msgstr ""\n' +
+    '"MIME-Version: 1.0\\n"\n' +
+    '"X-Generator: react-intl-po\\n"\n' +
+    '\n\n',
+  );
+});
+
+test('should return pot header, with a single comment, with CR in it', (t) => {
+  t.is(
+    potHeader({
+      comments: 'This is a multi-line\ncomment\n'
+    }),
+    '# This is a multi-line\n' +
+    '# comment\n' +
+    '# \n' +
+    'msgid ""\n' +
+    'msgstr ""\n' +
+    '"MIME-Version: 1.0\\n"\n' +
+    '"X-Generator: react-intl-po\\n"\n' +
+    '\n\n',
+  );
+});
+
+test('should return pot header, with a list of comments', (t) => {
+  t.is(
+    potHeader({
+      comments: ['A', 'B', 'C']
+    }),
+    '# A\n' +
+    '# B\n' +
+    '# C\n' +
+    'msgid ""\n' +
+    'msgstr ""\n' +
+    '"MIME-Version: 1.0\\n"\n' +
+    '"X-Generator: react-intl-po\\n"\n' +
+    '\n\n',
+  );
+});
+
+
+test('should return pot header, with all options', (t) => {
+  t.is(
+    potHeader({
+      comments: 'This is a single line comment',
+      projectIdVersion: 'FUBAR',
+      potCreationDate: new Date(1995,11,17,3,24,0),
+      charset: 'UTF-8',
+      encoding: '8bit'
+    }),
+    '# This is a single line comment\n' +
+    'msgid ""\n' +
+    'msgstr ""\n' +
+    '"Project-Id-Version: FUBAR\\n"\n' +
+    '"POT-Creation-Date: 1995-12-17T02:24:00.000Z\\n"\n' +
+    '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
+    '"Content-Transfer-Encoding: 8bit\\n"\n' +
+    '"MIME-Version: 1.0\\n"\n' +
+    '"X-Generator: react-intl-po\\n"\n' +
+    '\n\n',
+  );
+});

--- a/test/potHeader.test.js
+++ b/test/potHeader.test.js
@@ -30,7 +30,7 @@ test('should return pot header, without empty options', (t) => {
 test('should return pot header, with a single comment', (t) => {
   t.is(
     potHeader({
-      comments: 'This is a single line comment'
+      comments: 'This is a single line comment',
     }),
     '# This is a single line comment\n' +
     'msgid ""\n' +
@@ -44,7 +44,7 @@ test('should return pot header, with a single comment', (t) => {
 test('should return pot header, with a single comment, with CR in it', (t) => {
   t.is(
     potHeader({
-      comments: 'This is a multi-line\ncomment\n'
+      comments: 'This is a multi-line\ncomment\n',
     }),
     '# This is a multi-line\n' +
     '# comment\n' +
@@ -60,7 +60,7 @@ test('should return pot header, with a single comment, with CR in it', (t) => {
 test('should return pot header, with a list of comments', (t) => {
   t.is(
     potHeader({
-      comments: ['A', 'B', 'C']
+      comments: ['A', 'B', 'C'],
     }),
     '# A\n' +
     '# B\n' +
@@ -79,9 +79,9 @@ test('should return pot header, with all options', (t) => {
     potHeader({
       comments: 'This is a single line comment',
       projectIdVersion: 'FUBAR',
-      potCreationDate: new Date(1995,11,17,3,24,0),
+      potCreationDate: new Date(1995, 11, 17, 3, 24, 0),
       charset: 'UTF-8',
-      encoding: '8bit'
+      encoding: '8bit',
     }),
     '# This is a single line comment\n' +
     'msgid ""\n' +

--- a/test/potHeader.test.js
+++ b/test/potHeader.test.js
@@ -79,7 +79,7 @@ test('should return pot header, with all options', (t) => {
     potHeader({
       comments: 'This is a single line comment',
       projectIdVersion: 'FUBAR',
-      potCreationDate: new Date(1995, 11, 17, 3, 24, 0),
+      potCreationDate: new Date(Date.UTC(1995, 11, 17, 3, 24, 0)),
       charset: 'UTF-8',
       encoding: '8bit',
     }),
@@ -87,7 +87,7 @@ test('should return pot header, with all options', (t) => {
     'msgid ""\n' +
     'msgstr ""\n' +
     '"Project-Id-Version: FUBAR\\n"\n' +
-    '"POT-Creation-Date: 1995-12-17T02:24:00.000Z\\n"\n' +
+    '"POT-Creation-Date: 1995-12-17T03:24:00.000Z\\n"\n' +
     '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
     '"Content-Transfer-Encoding: 8bit\\n"\n' +
     '"MIME-Version: 1.0\\n"\n' +

--- a/test/readAllMessageAsObjectSync.test.js
+++ b/test/readAllMessageAsObjectSync.test.js
@@ -15,6 +15,7 @@ test('should return messages object with default mapper', (t) => {
           description: 'The error message when api response as 404 not found',
           defaultMessage: 'The device is now private or deleted.',
           filename: './messages/src/containers/App/App.json',
+          mappedBy: 'defaultMessage',
         },
       ],
       'Go to MCS website': [
@@ -23,12 +24,14 @@ test('should return messages object with default mapper', (t) => {
           description: 'Click error Button',
           defaultMessage: 'Go to MCS website',
           filename: './messages/src/containers/App/App.json',
+          mappedBy: 'defaultMessage',
         },
         {
           id: 'NotFound.errorButton',
           description: 'Click error Button',
           defaultMessage: 'Go to MCS website',
           filename: './messages/src/containers/NotFound/messages.json',
+          mappedBy: 'defaultMessage',
         },
       ],
       Creator: [
@@ -37,12 +40,14 @@ test('should return messages object with default mapper', (t) => {
           description: 'Creator',
           defaultMessage: 'Creator',
           filename: './messages/src/containers/App/App.json',
+          mappedBy: 'defaultMessage',
         },
         {
           id: 'NotFound.Creator',
           description: 'Creator',
           defaultMessage: 'Creator',
           filename: './messages/src/containers/NotFound/messages.json',
+          mappedBy: 'defaultMessage',
         },
       ],
     },
@@ -53,7 +58,7 @@ test('should return messages object with description as key', (t) => {
   t.deepEqual(
     readAllMessageAsObjectSync(
       './messages/**/App.json',
-      (message, filename) => ({ [message.description]: [{ ...message, filename }]}),
+      (message, filename) => ({ [message.description]: [{ ...message, filename, mappedBy: 'description' }]}),
     ),
     {
       'The error message when api response as 404 not found': [
@@ -62,6 +67,7 @@ test('should return messages object with description as key', (t) => {
           description: 'The error message when api response as 404 not found',
           defaultMessage: 'The device is now private or deleted.',
           filename: './messages/src/containers/App/App.json',
+          mappedBy: 'description',
         },
       ],
       'Click error Button': [
@@ -70,6 +76,7 @@ test('should return messages object with description as key', (t) => {
           description: 'Click error Button',
           defaultMessage: 'Go to MCS website',
           filename: './messages/src/containers/App/App.json',
+          mappedBy: 'description',
         },
       ],
       Creator: [
@@ -78,6 +85,7 @@ test('should return messages object with description as key', (t) => {
           description: 'Creator',
           defaultMessage: 'Creator',
           filename: './messages/src/containers/App/App.json',
+          mappedBy: 'description',
         },
       ],
     },


### PR DESCRIPTION
1- Added a new property to message named  defaulted to 'defaultMessage' in default mapper and key in custom mapper
2- If a message mappedBy property truthy and not equal to 'defaultMessage' then a  comment is added to current message
3- Also added a potCommentMultiLineWrapper helper to avoid breaking comments if comment has line break in it