### PR TITLE
Escape quotes in msgId

### DIFF
--- a/src/potFormater.js
+++ b/src/potFormater.js
@@ -58,7 +58,7 @@ const potCommentsFormater = messageList =>
 const potFormater = messageObject =>
   Object.keys(messageObject) // return array of id
     .sort()
-    .map(id => `${potCommentsFormater(messageObject[id])}msgid "${id}"\nmsgstr ""\n`)
+    .map(id => `${potCommentsFormater(messageObject[id])}msgid ${JSON.stringify(id)}\nmsgstr ""\n`)
     .join('\n');
 
 export default potFormater;

--- a/test/__snapshots__/potFormater.test.js.snap
+++ b/test/__snapshots__/potFormater.test.js.snap
@@ -12,6 +12,19 @@ msgstr \"\"
 "
 `;
 
+exports[`test should return pot formatted string, with double quotes escaped 1`] = `
+"#: ./messages/src/containers/NotFound/messages.json
+#. [NotFound.errorButton] - My description
+#. is
+#. quite
+#. long.
+#. defaultMessage is:
+#. This is \"quoted\"
+msgid \"This is \\\"quoted\\\"\"
+msgstr \"\"
+"
+`;
+
 exports[`test should return pot formatted string, with multi line values 1`] = `
 "#: ./messages/src/containers/NotFound/messages.json
 #. [NotFound.errorButton] - My description

--- a/test/potFormater.test.js
+++ b/test/potFormater.test.js
@@ -53,3 +53,18 @@ it('should return pot formatted string, with multi line values', () => {
     }),
   ).toMatchSnapshot();
 });
+
+it('should return pot formatted string, with double quotes escaped', () => {
+  expect(
+    potFormater({
+      'This is "quoted"': [
+        {
+          id: 'NotFound.errorButton',
+          description: 'My description\nis\nquite\nlong.',
+          defaultMessage: 'This is "quoted"',
+          filename: './messages/src/containers/NotFound/messages.json',
+        },
+      ],
+    }),
+  ).toMatchSnapshot();
+});


### PR DESCRIPTION
Excellent library BTW 👍 

This seems to be right way to fix this problem but obviously open to other ideas.

Discovered this when Transifex returned the following error:

```
Could not import file: Syntax error in po file None (line 110): unescaped double quote found
```