### PR TITLE
Custom lang mapper regex and index

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-intl-po",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Extract POT from react-intl and convert back to json.",
   "author": "Michael Hsu",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-intl-po",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Extract POT from react-intl and convert back to json.",
   "author": "Michael Hsu",
   "license": "MIT",

--- a/src/cli.js
+++ b/src/cli.js
@@ -33,6 +33,14 @@ program
     '-c, --message-context [context]',
     'Translation message context (defaults to no context)',
   )
+  .option(
+    '-l --lang-mapper-pattern <pattern>',
+    'Custom regex to use for lang mapping.',
+  )
+  .option(
+    '-i --lang-mapper-pattern-index [index]',
+    'When specifying a custom lang-mapper-pattern, the index of match to use for the lang mapping. Default is 1, index is ignored if not using a custom lang mapping regex',
+  )
   .action(require('./filterPOAndWriteTranslateSync'));
 
 program.parse(process.argv);

--- a/test/__snapshots__/filterPOAndWriteTranslateSync.test.js.snap
+++ b/test/__snapshots__/filterPOAndWriteTranslateSync.test.js.snap
@@ -64,6 +64,28 @@ exports[`should output one file per locale if a *directory* is set 2`] = `
 }
 `;
 
+exports[`should output one file per locale if a *directory* is set, using custom lang mapper regex 1`] = `
+{
+  "App.errorMessage": "",
+  "App.errorButton": "",
+  "NotFound.errorButton": "",
+  "App.Creator 1": "",
+  "App.Creator 2": "",
+  "NotFound.Creator": ""
+}
+`;
+
+exports[`should output one file per locale if a *directory* is set, using custom lang mapper regex 2`] = `
+{
+  "App.errorMessage": "",
+  "App.errorButton": "",
+  "NotFound.errorButton": "",
+  "App.Creator 1": "",
+  "App.Creator 2": "",
+  "NotFound.Creator": ""
+}
+`;
+
 exports[`should output one merged file if a *json file* is set 1`] = `
 {
   "zh-CN": {

--- a/test/alternate_po/zh_CN/LC_MESSAGES/messages.po
+++ b/test/alternate_po/zh_CN/LC_MESSAGES/messages.po
@@ -1,0 +1,20 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2017-02-01T11:23:12.000Z\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"MIME-Version: 1.0\n"
+"X-Generator: react-intl-po\n"
+
+
+#: ./test/messages/src/containers/App/App.json
+#. [App.Creator 1] - Creator 1
+msgctxt "App.Creator 1"
+msgid "Creator"
+msgstr "建立者（簡中1）"
+
+#: ./test/messages/src/containers/App/App.json
+#. [App.Creator 2] - Creator 2
+msgctxt "App.Creator 2"
+msgid "Creator"
+msgstr "建立者（簡中2）"

--- a/test/alternate_po/zh_TW/LC_MESSAGES/messages.po
+++ b/test/alternate_po/zh_TW/LC_MESSAGES/messages.po
@@ -1,0 +1,20 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2017-02-01T11:23:12.000Z\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"MIME-Version: 1.0\n"
+"X-Generator: react-intl-po\n"
+
+
+#: ./test/messages/src/containers/App/App.json
+#. [App.Creator 1] - Creator 1
+msgctxt "App.Creator 1"
+msgid "Creator"
+msgstr "建立者（繁中1）"
+
+#: ./test/messages/src/containers/App/App.json
+#. [App.Creator 2] - Creator 2
+msgctxt "App.Creator 2"
+msgid "Creator"
+msgstr "建立者（繁中2）"

--- a/test/filterPOAndWriteTranslateSync.test.js
+++ b/test/filterPOAndWriteTranslateSync.test.js
@@ -32,6 +32,26 @@ it('should output one file per locale if a *directory* is set', () => {
   ).toMatchSnapshot();
 });
 
+it('should output one file per locale if a *directory* is set, using custom lang mapper regex', () => {
+  const messagesPattern = './test/messages/**/*.json';
+  const output = './test/temp/translations';
+  const langMapperPattern = /.*\/(\w{1,3}_\w{1,3})\/.*/;
+  const langMapperPatternIndex = 1;
+
+  filterPOAndWriteTranslateSync('./test/alternate_po/**/messages.po', {
+    messagesPattern,
+    langMapperPattern,
+    langMapperPatternIndex,
+    output,
+  });
+  expect(
+    JSON.parse(fs.readFileSync(`${output}/zh_CN.json`, 'utf8')),
+  ).toMatchSnapshot();
+  expect(
+    JSON.parse(fs.readFileSync(`${output}/zh_TW.json`, 'utf8')),
+  ).toMatchSnapshot();
+});
+
 it('should output correct filter merged file with id as messageKey', () => {
   const messagesPattern = './test/messages/**/*.json';
   const output = './test/temp/translations-id.json';


### PR DESCRIPTION
our legacy code uses a directory hierarchy that's incompatible with react-intl-po. This update allows users to customize the mapper pattern and the match index