### PR TITLE
fix: Do not crash on empty message

### DIFF
--- a/src/filterPOAndWriteTranslateSync.js
+++ b/src/filterPOAndWriteTranslateSync.js
@@ -44,7 +44,10 @@ function filterPOAndWriteTranslateSync(
     R.indexBy(R.prop('id')),
     // 5. Object { id: [] }
     R.mapObjIndexed(
-      R.converge(R.concat, [getContext(messageContext), R.prop(messageKey)]),
+      R.converge(R.concat, [
+        getContext(messageContext),
+        R.propOr('', messageKey),
+      ]),
     ),
     // 6. Object { id: key }, key = (messageContext + messagekey)
   )(messagesPattern, messageKey, messageContext);

--- a/test/__snapshots__/extractAndWritePOTFromMessagesSync.test.js.snap
+++ b/test/__snapshots__/extractAndWritePOTFromMessagesSync.test.js.snap
@@ -25,6 +25,13 @@ msgid "App.Creator 2"
 msgstr ""
 
 #: ./test/messages/src/containers/App/App.json
+#. [App.Creator Empty message] - An Empty message
+#. defaultMessage is:
+#. 
+msgid "App.Creator Empty message"
+msgstr ""
+
+#: ./test/messages/src/containers/App/App.json
 #. [App.errorButton] - Click error Button
 #. defaultMessage is:
 #. Go to MCS website
@@ -63,6 +70,13 @@ msgstr ""
 "MIME-Version: 1.0\\n"
 "X-Generator: react-intl-po\\n"
 
+
+#: ./test/messages/src/containers/App/App.json
+#. [App.Creator Empty message] - An Empty message
+#. defaultMessage is:
+#. 
+msgid ""
+msgstr ""
 
 #: ./test/messages/src/containers/App/App.json
 #. [App.Creator 1] - Creator 1
@@ -108,6 +122,14 @@ msgstr ""
 "MIME-Version: 1.0\\n"
 "X-Generator: react-intl-po\\n"
 
+
+#: ./test/messages/src/containers/App/App.json
+#. [App.Creator Empty message] - An Empty message
+#. defaultMessage is:
+#. 
+msgctxt "App.Creator Empty message"
+msgid ""
+msgstr ""
 
 #: ./test/messages/src/containers/App/App.json
 #. [App.Creator 1] - Creator 1

--- a/test/__snapshots__/filterPOAndWriteTranslateSync.test.js.snap
+++ b/test/__snapshots__/filterPOAndWriteTranslateSync.test.js.snap
@@ -8,7 +8,8 @@ exports[`should output correct filter merged file with id as messageContext 1`] 
     "NotFound.errorButton": "",
     "App.Creator 1": "建立者（簡中1）",
     "App.Creator 2": "建立者（簡中2）",
-    "NotFound.Creator": ""
+    "NotFound.Creator": "",
+    "App.Creator Empty message": ""
   },
   "zh-TW": {
     "App.errorMessage": "",
@@ -16,7 +17,8 @@ exports[`should output correct filter merged file with id as messageContext 1`] 
     "NotFound.errorButton": "",
     "App.Creator 1": "建立者（繁中1）",
     "App.Creator 2": "建立者（繁中2）",
-    "NotFound.Creator": ""
+    "NotFound.Creator": "",
+    "App.Creator Empty message": ""
   }
 }
 `;
@@ -28,6 +30,7 @@ exports[`should output correct filter merged file with id as messageKey 1`] = `
     "App.errorButton": "",
     "App.Creator 1": "建立者（簡中1）",
     "App.Creator 2": "建立者（簡中2）",
+    "App.Creator Empty message": "",
     "NotFound.errorButton": "",
     "NotFound.Creator": ""
   },
@@ -36,6 +39,7 @@ exports[`should output correct filter merged file with id as messageKey 1`] = `
     "App.errorButton": "",
     "App.Creator 1": "建立者（繁中1）",
     "App.Creator 2": "建立者（繁中2）",
+    "App.Creator Empty message": "",
     "NotFound.errorButton": "",
     "NotFound.Creator": ""
   }
@@ -50,7 +54,8 @@ exports[`should output json file with prefix char if indentation char is used 1`
 				"NotFound.errorButton": "",
 				"App.Creator 1": "建立者（簡中）",
 				"App.Creator 2": "建立者（簡中）",
-				"NotFound.Creator": "建立者（簡中）"
+				"NotFound.Creator": "建立者（簡中）",
+				"App.Creator Empty message": ""
 		},
 		"zh-TW": {
 				"App.errorMessage": "",
@@ -58,7 +63,8 @@ exports[`should output json file with prefix char if indentation char is used 1`
 				"NotFound.errorButton": "",
 				"App.Creator 1": "建立者",
 				"App.Creator 2": "建立者",
-				"NotFound.Creator": "建立者"
+				"NotFound.Creator": "建立者",
+				"App.Creator Empty message": ""
 		}
 }
 `;
@@ -71,7 +77,8 @@ exports[`should output json file with spaces if indentation number is used 1`] =
         "NotFound.errorButton": "",
         "App.Creator 1": "建立者（簡中）",
         "App.Creator 2": "建立者（簡中）",
-        "NotFound.Creator": "建立者（簡中）"
+        "NotFound.Creator": "建立者（簡中）",
+        "App.Creator Empty message": ""
     },
     "zh-TW": {
         "App.errorMessage": "",
@@ -79,7 +86,8 @@ exports[`should output json file with spaces if indentation number is used 1`] =
         "NotFound.errorButton": "",
         "App.Creator 1": "建立者",
         "App.Creator 2": "建立者",
-        "NotFound.Creator": "建立者"
+        "NotFound.Creator": "建立者",
+        "App.Creator Empty message": ""
     }
 }
 `;
@@ -91,7 +99,8 @@ exports[`should output one file per locale if a *directory* is set 1`] = `
   "NotFound.errorButton": "",
   "App.Creator 1": "建立者（簡中）",
   "App.Creator 2": "建立者（簡中）",
-  "NotFound.Creator": "建立者（簡中）"
+  "NotFound.Creator": "建立者（簡中）",
+  "App.Creator Empty message": ""
 }
 `;
 
@@ -102,7 +111,8 @@ exports[`should output one file per locale if a *directory* is set 2`] = `
   "NotFound.errorButton": "",
   "App.Creator 1": "建立者",
   "App.Creator 2": "建立者",
-  "NotFound.Creator": "建立者"
+  "NotFound.Creator": "建立者",
+  "App.Creator Empty message": ""
 }
 `;
 
@@ -113,7 +123,8 @@ exports[`should output one file per locale if a *directory* is set, using custom
   "NotFound.errorButton": "",
   "App.Creator 1": "",
   "App.Creator 2": "",
-  "NotFound.Creator": ""
+  "NotFound.Creator": "",
+  "App.Creator Empty message": ""
 }
 `;
 
@@ -124,7 +135,8 @@ exports[`should output one file per locale if a *directory* is set, using custom
   "NotFound.errorButton": "",
   "App.Creator 1": "",
   "App.Creator 2": "",
-  "NotFound.Creator": ""
+  "NotFound.Creator": "",
+  "App.Creator Empty message": ""
 }
 `;
 
@@ -136,7 +148,8 @@ exports[`should output one merged file if a *json file* is set 1`] = `
     "NotFound.errorButton": "",
     "App.Creator 1": "建立者（簡中）",
     "App.Creator 2": "建立者（簡中）",
-    "NotFound.Creator": "建立者（簡中）"
+    "NotFound.Creator": "建立者（簡中）",
+    "App.Creator Empty message": ""
   },
   "zh-TW": {
     "App.errorMessage": "",
@@ -144,7 +157,8 @@ exports[`should output one merged file if a *json file* is set 1`] = `
     "NotFound.errorButton": "",
     "App.Creator 1": "建立者",
     "App.Creator 2": "建立者",
-    "NotFound.Creator": "建立者"
+    "NotFound.Creator": "建立者",
+    "App.Creator Empty message": ""
   }
 }
 `;
@@ -154,6 +168,7 @@ exports[`should output sorted file if sortById is used 1`] = `
   "zh-CN": {
     "App.Creator 1": "建立者（簡中）",
     "App.Creator 2": "建立者（簡中）",
+    "App.Creator Empty message": "",
     "App.errorButton": "",
     "App.errorMessage": "",
     "NotFound.Creator": "建立者（簡中）",
@@ -162,6 +177,7 @@ exports[`should output sorted file if sortById is used 1`] = `
   "zh-TW": {
     "App.Creator 1": "建立者",
     "App.Creator 2": "建立者",
+    "App.Creator Empty message": "",
     "App.errorButton": "",
     "App.errorMessage": "",
     "NotFound.Creator": "建立者",

--- a/test/__snapshots__/readAllMessageAsObjectSync.test.js.snap
+++ b/test/__snapshots__/readAllMessageAsObjectSync.test.js.snap
@@ -49,6 +49,16 @@ exports[`should return messages object with default messageKey 1`] = `
         "filename": "./test/messages/src/containers/NotFound/messages.json"
       }
     ]
+  },
+  "": {
+    "": [
+      {
+        "id": "App.Creator Empty message",
+        "description": "An Empty message",
+        "defaultMessage": "",
+        "filename": "./test/messages/src/containers/App/App.json"
+      }
+    ]
   }
 }
 `;
@@ -91,6 +101,16 @@ exports[`should return messages object with description as key 1`] = `
         "id": "App.Creator 2",
         "description": "Creator 2",
         "defaultMessage": "Creator",
+        "filename": "./test/messages/src/containers/App/App.json"
+      }
+    ]
+  },
+  "An Empty message": {
+    "": [
+      {
+        "id": "App.Creator Empty message",
+        "description": "An Empty message",
+        "defaultMessage": "",
         "filename": "./test/messages/src/containers/App/App.json"
       }
     ]
@@ -153,6 +173,16 @@ exports[`should return messages object with id as context 1`] = `
         "filename": "./test/messages/src/containers/NotFound/messages.json"
       }
     ]
+  },
+  "": {
+    "App.Creator Empty message": [
+      {
+        "id": "App.Creator Empty message",
+        "description": "An Empty message",
+        "defaultMessage": "",
+        "filename": "./test/messages/src/containers/App/App.json"
+      }
+    ]
   }
 }
 `;
@@ -195,6 +225,16 @@ exports[`should return messages object with id as key 1`] = `
         "id": "App.Creator 2",
         "description": "Creator 2",
         "defaultMessage": "Creator",
+        "filename": "./test/messages/src/containers/App/App.json"
+      }
+    ]
+  },
+  "App.Creator Empty message": {
+    "": [
+      {
+        "id": "App.Creator Empty message",
+        "description": "An Empty message",
+        "defaultMessage": "",
         "filename": "./test/messages/src/containers/App/App.json"
       }
     ]

--- a/test/messages/src/containers/App/App.json
+++ b/test/messages/src/containers/App/App.json
@@ -18,5 +18,10 @@
     "id": "App.Creator 2",
     "description": "Creator 2",
     "defaultMessage": "Creator"
+  },
+  {
+    "id": "App.Creator Empty message",
+    "description": "An Empty message",
+    "defaultMessage": ""
   }
 ]


### PR DESCRIPTION
Encountered an error during `po2json` when a source message was empty. This change handles such the scenario gracefully.